### PR TITLE
refactor: rename _input_text_element_node to input_text_element_node

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -1070,7 +1070,7 @@ class BrowserContext:
 			return None
 
 	@time_execution_async('--input_text_element_node')
-	async def _input_text_element_node(self, element_node: DOMElementNode, text: str):
+	async def input_text_element_node(self, element_node: DOMElementNode, text: str):
 		"""
 		Input text into an element with proper error handling and state management.
 		Handles different types of input fields and ensures proper element state before input.

--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -156,7 +156,7 @@ class Controller(Generic[Context]):
 				raise Exception(f'Element index {params.index} does not exist - retry or use alternative actions')
 
 			element_node = await browser.get_dom_element_by_index(params.index)
-			await browser._input_text_element_node(element_node, params.text)
+			await browser.input_text_element_node(element_node, params.text)
 			if not has_sensitive_data:
 				msg = f'⌨️  Input {params.text} into index {params.index}'
 			else:


### PR DESCRIPTION
Changed the variable name from _input_text_element_node to input_text_element_node to make it accessible outside its original scope since it was being used externally.